### PR TITLE
refactor: remove resolve dependency

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -1,9 +1,7 @@
-var resolve = require('resolve');
-
 module.exports = function (cwd, moduleName, register) {
   var result;
   try {
-    var modulePath = resolve.sync(moduleName, { basedir: cwd });
+    var modulePath = require.resolve(moduleName, { paths: [cwd] });
     result = require(modulePath);
     if (typeof register === 'function') {
       register(result);

--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
     "pretest": "rm -rf tmp/ && npm run lint",
     "test": "nyc mocha --async-only"
   },
-  "dependencies": {
-    "resolve": "^1.20.0"
-  },
   "devDependencies": {
     "eslint": "^7.21.0",
     "eslint-config-gulp": "^5.0.1",


### PR DESCRIPTION
This replaces the dependency on resolve with node's native require.resolve method which supports custom paths as of [node 8.9.0](https://nodejs.org/dist/latest-v8.x/docs/api/modules.html#modules_require_resolve_request_options).

This will address false positive findings related to [resolve's `monorepo-symlink-test`](https://github.com/browserify/resolve/issues/312) file.